### PR TITLE
Fix annotations to match the example code

### DIFF
--- a/guides/swagger.md
+++ b/guides/swagger.md
@@ -315,6 +315,7 @@ Let's do the `get("/")` route first.
 Right now, it looks like this:
 
 ```scala
+
   get("/"){
     params.get("name") match {
       case Some(name) => FlowerData.all filter (_.name.toLowerCase contains name.toLowerCase)
@@ -326,14 +327,13 @@ Right now, it looks like this:
 We'll need to add some information to the method in order to tell Swagger what this method does, what parameters it can take, and what it responds with.
 
 ```scala
-
-  val getFlowers = 
-    (apiOperation[List[Flower]]("getFlowers")
-      summary "Show all flowers"
-      notes "Shows all the flowers in the flower shop. You can search it too."
-      parameter queryParam[Option[String]]("name").description("A name to search for"))
-
-  get("/", operation(getFlowers)) {
+  get("/",
+    summary("Show all flowers"),
+    nickname("getFlowers"),
+    responseClass("List[Flower]"),
+    parameters(Parameter("name", "A name to search for", DataType.String, paramType = ParamType.Query, required = false)),
+    endpoint(""),
+    notes("Shows all the flowers in the flower shop. You can search it too.")){
     params.get("name") match {
       case Some(name) => FlowerData.all filter (_.name.toLowerCase contains name.toLowerCase)
       case None => FlowerData.all
@@ -367,14 +367,16 @@ We can do the same to our `get(/:slug)` route. Change it from this:
 to this:
 
 ```scala
-  val findBySlug = 
-    (apiOperation[Flower]("findBySlug")
-      summary "Find by slug"
-      parameters (
-        pathParam[String]("slug").description("Slug of flower that needs to be fetched")
-      ))
-
-  get("/:slug", operation(findBySlug)) {
+  get("/:slug",
+    summary("Find by slug"),
+    nickname("findBySlug"),
+    responseClass("Flower"),
+    endpoint("{slug}"),
+    notes("Returns the flower for the provided slug, if a matching flower exists."),
+    parameters(
+      Parameter("slug", "Slug of flower that needs to be fetched",
+        DataType.String,
+        paramType = ParamType.Path))) {
     FlowerData.all find (_.slug == params("slug")) match {
       case Some(b) => b
       case None => halt(404)


### PR DESCRIPTION
The code for the API annotations in the swagger guide are out of date. The explanation matches what is in the swagger example code but the code doesn't so the explanation doesn't make any sense. I fixed the code in the guide to be what is in the swagger example code.
