### PR TITLE
Changed IntelliJ IDEA plugin command from 'idea' to the current 'gen-idea'.

### DIFF
--- a/getting-started/ide-support.md
+++ b/getting-started/ide-support.md
@@ -53,10 +53,10 @@ project will work as expected in the IDE.
 
 ```
 $ ./sbt
-> idea
+> gen-idea
 ```
 
-Be sure to re-run `./sbt idea` every time you add or update a dependency in
+Be sure to re-run `./sbt gen-idea` every time you add or update a dependency in
 `project/build.scala`.
 
 ## ENSIME (for Emacs)


### PR DESCRIPTION
Just fixed the IDE guide to reflect the proper command for generating an IDEA project using the IDEA SBT plugin.
