### PR TITLE
Updated slug size limitation to 300MB

### DIFF
--- a/guides/deployment/heroku.md
+++ b/guides/deployment/heroku.md
@@ -170,7 +170,7 @@ Open your browser to to the URL provided right before `deployed to Heroku` in th
 ## 6. Limitations
 No app host is perfect. You should be aware of two limitations as you develop on Heroku:
 
-- Heroku ["slugs"](https://devcenter.heroku.com/articles/slug-compiler) (deployed apps with their dependencies) are limited to 200MB.
+- Heroku ["slugs"](https://devcenter.heroku.com/articles/slug-compiler) (deployed apps with their dependencies) are limited to 300MB.
 If your project has a large number of dependencies, you may exceed this limit.
 - At present, Heroku [does not support WebSockets](https://devcenter.heroku.com/articles/http-routing#websockets).
 


### PR DESCRIPTION
Heroku's slug size limit is updated to 300MB.

see https://github.com/scalatra/scalatra/issues/307
