### PR TITLE
Fixed scalatra issue #269 (wrongly reported on scalatra, rather scalatra-website)

### DIFF
--- a/getting-started/first-project.md
+++ b/getting-started/first-project.md
@@ -151,7 +151,7 @@ get("/") {
 Returning a raw string is not something you'll do particularly often -
 usually you will want to return formatted HTML that is the product of a
 templating system, or an output format like JSON.
-See the [views](../guides/views) section of our [guides](../guides) for more info.
+See the [views section of our guides](../guides) for more info.
 
 ## Automatic code reloading
 


### PR DESCRIPTION
Title of the issue: "First project" docs page links to a 403.
https://github.com/scalatra/scalatra/issues/269

Guides have no top level page listing all the guides in the section. I dropped the first link and
extended the link to guides to encompass the whole text.
