### PR TITLE
Fixed 2.3.x repository and Servlet API version

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,14 +188,13 @@ framework around that, we let <em>you</em> choose.</p>
     <tr>
       <td>2.3.0-SNAPSHOT</td>
       <td>Development</td>
-      <td><a href="http://github.com/scalatra/scalatra/tree/develop">develop</td>
+      <td><a href="http://github.com/scalatra/scalatra/tree/2.3.x_2.10">2.3.x</td>
       <td>
         <ul class="scala-versions">
-          <li>2.9.x</li>
           <li>2.10.x</li>
         </ul>
       </td>
-      <td>3.0</td>
+      <td>3.1</td>
       <td>N/A</td>
     </tr>
   </tbody>


### PR DESCRIPTION
- 2.3.x repository seems to be '2.3.x_2.10' 
- Scala 2.9.x won't be supported (?)
- depends on Servlet API 3.1.0
