### PR TITLE
ScalaTest 2.0 uses new names for FunSuite trait

### DIFF
--- a/guides/testing/scalatest.md
+++ b/guides/testing/scalatest.md
@@ -40,9 +40,9 @@ You get `ShouldMatchers` and `MustMatchers` for free.
 
 ```scala
 import org.scalatra.test.scalatest._
-import org.scalatest.FunSuite
+import org.scalatest.FunSuiteLike
 
-class HelloWorldServletTests extends ScalatraSuite with FunSuite {
+class HelloWorldServletTests extends ScalatraSuite with FunSuiteLike {
   // `HelloWorldServlet` is your app which extends ScalatraServlet
   addServlet(classOf[HelloWorldServlet], "/*")
 


### PR DESCRIPTION
See http://scalatest.org/user_guide/migrating_to_20 for details
