### PR TITLE
Fix Jetty launcher script in Heroku guide

### DIFF
--- a/guides/deployment/heroku.md
+++ b/guides/deployment/heroku.md
@@ -116,6 +116,7 @@ Create `src/main/scala/JettyLauncher.scala` with this code:
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.servlet.{ DefaultServlet, ServletContextHandler }
 import org.eclipse.jetty.webapp.WebAppContext
+import org.scalatra.servlet.ScalatraListener
 
 object JettyLauncher {
   def main(args: Array[String]) {
@@ -123,7 +124,7 @@ object JettyLauncher {
 
     val server = new Server(port)
     val context = new WebAppContext()
-    context.setContextPath "/"
+    context.setContextPath("/")
     context.setResourceBase("src/main/webapp")
 
     context.setEventListeners(Array(new ScalatraListener))


### PR DESCRIPTION
Adds missing import and braces, so the code compiles.
