### PR TITLE
Updated the dev port change documentation

### DIFF
--- a/guides/deployment/configuration.md
+++ b/guides/deployment/configuration.md
@@ -334,6 +334,12 @@ Scala's standard XML tools.
 ### Changing the port in development
 
 Add `port in container.Configuration := 8081` to `project/build.scala` if you would
-like your Scalatra app to run something other than the default port (8080).
+like your Scalatra app to run on something other than the default port (8080). 
+
+_You may need to add the following imports if you get errors upon adding the configuration above:_ 
+```scala
+import com.earldouglas.xsbtwebplugin.PluginKeys._
+import com.earldouglas.xsbtwebplugin.WebPlugin._
+```
 
 


### PR DESCRIPTION
Updated the documentation to include references to two import statements that are usually necessary to make the suggested dev port change work.  (I did this because it's kind of a goose chase to find those imports if you're new to Scalatra and unfamiliar with sbt).
