### PR TITLE
Small improvements to the ScalaTest documentation

### DIFF
--- a/guides/testing/scalatest.md
+++ b/guides/testing/scalatest.md
@@ -26,6 +26,8 @@ Convenience traits are provided for many `Suite` implementations:
 * `ScalatraJUnitSuite` (JUnit 4)
 * `ScalatraTestNGSuite`
 
+<span class="badge badge-info"><i class="icon-flag icon-white"></i></span>
+Notice that all the above traits are based on `ScalatraSuite` which mixes in `BeforeAndAfterAll`. It overrides both `beforeAll()` and `afterAll()` so it can start/stop the embedded HTTP server. Because of that, if your test classes also need to override `beforeAll` and/or `afterAll` just remember to call `super.beforeAll()` and/or `super.afterAll()`.
 
 #### Dependency
 

--- a/guides/testing/scalatest.md
+++ b/guides/testing/scalatest.md
@@ -53,9 +53,23 @@ class HelloWorldServletTests extends ScalatraSuite with FunSuiteLike {
       status should equal (200)
       body should include ("hi!")
     }
+
+    get("/path/to/something", ("param1" -> "value"), ("param2" -> "value2")) {
+      status should equal (200)
+      body should include ("hi!")
+    }
+
+    get("/path/to/something",
+        Map("param1" -> "value", "param2" -> "value2"),
+        Map("Header1" -> "header_value", "Header2" -> "header_value2")) {
+      status should equal (200)
+      body should include ("hi!")
+    }
   }
 }
 ```
+
+You can see all the available http different methods in the [API docs](/2.3/api/#org.scalatra.test.Client)
 
 The addServlet method is used here with `classOf[HelloWorldServlet]` to mount
 the HelloWorld servlet into the ScalaTest test.


### PR DESCRIPTION
The notice for the `BeforeAndAfterAll` is because it happened to me. The error it gave (below) was not straightforward to track down back to the lack of `EmbeddedJettyContainer.start()`/`EmbeddedJettyContainer.stop()` being effectively called. As overriding `beforeAll` and `afterAll` can be fairly common I guess it's better to warn people.

```
[info]   java.lang.IllegalArgumentException: requirement failed: The detected local port is < 1, that's not allowed
[info]   at scala.Predef$.require(Predef.scala:233)
[info]   at org.scalatra.test.EmbeddedJettyContainer$class.baseUrl(EmbeddedJettyContainer.scala:42)
[info]   at com.busk.searchserver.api.ExternalApiServletTest.baseUrl(ExternalApiServletTest.scala:30)
[info]   at org.scalatra.test.HttpComponentsClient$class.submit(HttpComponentsClient.scala:63)
[info]   at com.busk.searchserver.api.ExternalApiServletTest.submit(ExternalApiServletTest.scala:30)
[info]   at org.scalatra.test.Client$class.post(Client.scala:63)
[info]   at com.busk.searchserver.api.ExternalApiServletTest.post(ExternalApiServletTest.scala:30)
[info]   at org.scalatra.test.Client$class.post(Client.scala:61)
[info]   at com.busk.searchserver.api.ExternalApiServletTest.post(ExternalApiServletTest.scala:30)
[info]   at com.busk.searchserver.api.ExternalApiServletTest$$anonfun$7.apply$mcV$sp(ExternalApiServletTest.scala:115)
```

PS: if you override just `afterAll` (that is, forget to call `stop()`) it doesn't give any error.