### PR TITLE
Correct path to c3p0.properties in slick.md

### DIFF
--- a/guides/persistence/slick.md
+++ b/guides/persistence/slick.md
@@ -127,7 +127,7 @@ class ScalatraBootstrap extends LifeCycle {
 }
 ```
 
-The connection pool configuration `src/main/resource/c3p0.properties` looks like this:
+The connection pool configuration `src/main/resources/c3p0.properties` looks like this:
 
 ```ini
 c3p0.driverClass=org.h2.Driver


### PR DESCRIPTION
`resource` changed to `resources`.