### PR TITLE
Update Heroku docs

### DIFF
--- a/guides/deployment/heroku.md
+++ b/guides/deployment/heroku.md
@@ -144,4 +144,10 @@ To git@heroku.com:polar-atoll-9149.git
 * [new branch]      master -> master
 ```
 
-Open your browser to to the URL provided right before `deployed to Heroku` in the output.
+Open your browser to to the URL provided right before `deployed to Heroku` in the output. Or just run:
+
+```bash
+$ heroku open
+```
+
+For more information on using Scala with Heroku see the [Heroku DevCenter](https://devcenter.heroku.com/articles/scala-support).

--- a/guides/deployment/heroku.md
+++ b/guides/deployment/heroku.md
@@ -105,6 +105,20 @@ And don't forget to set your servlet mapping (you probably already have somethin
 context.mount(new MyScalatraServlet, "/*")
 ```
 
+### Tell Heroku how to run your app
+
+Heroku will detect the `target/universal/stage/bin/<app-name>` script generated
+by sbt-native-packager, so it will know how to run your app by default.
+
+However, you may want to customize how your app starts.  In that case, create
+a `Procfile` with contents such as:
+
+```
+web: target/universal/stage/bin/<app-name> -Dhttp.port=$PORT -Dother.prop=someValue
+```
+
+And replace `<app-name>` with the name of your app defined in `build.scala`.
+
 ## 5. Deploy
 
 If you haven't set up your project as a Git repo, do so.

--- a/guides/deployment/heroku.md
+++ b/guides/deployment/heroku.md
@@ -105,7 +105,7 @@ And don't forget to set your servlet mapping (you probably already have somethin
 context.mount(new MyScalatraServlet, "/*")
 ```
 
-### Tell Heroku how to run your app
+### Tell Heroku how to run your app (optional)
 
 Heroku will detect the `target/universal/stage/bin/<app-name>` script generated
 by sbt-native-packager, so it will know how to run your app by default.


### PR DESCRIPTION
I've updated the Heroku documentation for the modern age. I will also submit a PR to update this project:
https://github.com/scalatra/scalatra-website-examples/tree/master/2.3/deployment/scalatra-heroku

Here is a summary of what I've changed:

+ Use sbt-native-packager instead of sbt-start-script
+ Removed the default `Procfile` but added a discussion on custom `Procfile` (optional)
+ Removed some outdated references (such as `--stack cedar`)
+ Removed the limitations discussion because WebSockets are support, and sbt-native-packager usually fixes the slug size problem because it allows Heroku to prune your app.