### PR TITLE
Update first-project.md

### DIFF
--- a/getting-started/first-project.md
+++ b/getting-started/first-project.md
@@ -174,8 +174,7 @@ To recompile and reload your application automatically, run the following:
 
 ```bash
 $ ./sbt
-> container:start
-> ~ ;copy-resources;aux-compile
+> ~container:start
 ```
 
 Now that you've got a (rather simplistic) running application, you may want


### PR DESCRIPTION
Resolves the `Not a valid command: aux-compile` error. 
Aux-compile went away with xsbt-web-plugin 1.0. It has been simplified by the plugin:
`~container:start`