### PR TITLE
Update commands.md

### DIFF
--- a/guides/formats/commands.md
+++ b/guides/formats/commands.md
@@ -130,8 +130,7 @@ chmod +x sbt
 Now you're in the sbt shell, start the server and enable recompilation:
 
 ```
-container:start
-~;copy-resources;aux-compile
+~container:start
 ```
 
 ### Setting up a model and fake datastore


### PR DESCRIPTION
Aux-compile went away with xsbt-web-plugin 1.0. It has been simplified by the plugin:
`~container:start`