### PR TITLE
Fixes heroku deployment docs JettyLauncher port

### DIFF
--- a/guides/deployment/heroku.md
+++ b/guides/deployment/heroku.md
@@ -82,7 +82,7 @@ import org.scalatra.servlet.ScalatraListener
 
 object JettyLauncher {
   def main(args: Array[String]) {
-    val port = if(System.getenv("PORT") != null) System.getenv("PORT").toInt else 8080
+    val port = if(System.getProperty("http.port") != null) System.getProperty("http.port").toInt else 8080
 
     val server = new Server(port)
     val context = new WebAppContext()


### PR DESCRIPTION
JettyLauncher port should use port given by http.port system property and not $PORT environment variable to be consistent with following Procfile line

`web: target/universal/stage/bin/<app-name> -Dhttp.port=$PORT -Dother.prop=someValue`