### PR TITLE
Update scalatra_version and json4s_version to fix json section of user guide

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,9 +9,9 @@ url: http://localhost:4000/
 examples: https://github.com/scalatra/scalatra-website-examples/tree/master/2.4/
 
 jetty_version: 9.2.10.v20150310
-scalatra_version: 2.4.0.RC1
+scalatra_version: 2.4.1
 servlet_version: 3.1.0
-json4s_version: 3.3.0.RC1
+json4s_version: 3.3.0
 swagger_version: 1.2.0
 logback_version: 1.1.3
 start_script_plugin_version: 0.5.3

--- a/guides/formats/json.md
+++ b/guides/formats/json.md
@@ -90,7 +90,7 @@ The first thing you'll need is Scalatra's JSON handling library. The second thin
 In the root of your generated project, you'll find a file called `project/build.scala`. Open that up, and add the following two lines to the `libraryDependencies` sequence, after the other scalatra-related lines:
 
 ```scala
-  "org.scalatra" %% "scalatra-json" % "{{ site.scalatra_version }}",
+  "org.scalatra" %% "scalatra-json" % ScalatraVersion,
   "org.json4s"   %% "json4s-jackson" % "{{ site.json4s_version }}",
 ```
 


### PR DESCRIPTION
See #120. Pretty sure the scalatra_version should be bumped as well to `2.4.1` so I updated it at the same time.

Tested the change by following the updated json guide step-by-step without issue.