### PR TITLE
Mention MetricsSupportExtensions import

### DIFF
--- a/guides/monitoring/metrics.md
+++ b/guides/monitoring/metrics.md
@@ -47,9 +47,11 @@ class ScalatraBootstrap extends LifeCycle with MetricsBootstrap {
 
 ### Metrics Servlets
 
-Convenience methods are provided to mount the metrics servlets at a specified path from the init method.
+Convenience methods to mount the metrics servlets at a specified path from the init method are provided in ```MetricsSupportExtensions```.
 
 ```scala
+import org.scalatra.metrics.MetricsSupportExtensions._
+
 class ScalatraBootstrap extends LifeCycle with MetricsBootstrap {
   override def init(context: ServletContext) =
   {


### PR DESCRIPTION
The documentation doesn't mention that to have the convenience methods we need the implicit org.scalatra.metrics.MetricsSupportExtensions.metricsSupportExtensions
