### PR TITLE
how to install giter8 via brew

### DIFF
--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -79,6 +79,13 @@ source ~/.bashrc       # (Linux)
   <p>Depending on your connection speed, this can take a bit of time, as
   `conscript` downloads quite a few Scala dependencies.</p>
 
+Alternatively, you can install `giter8` on a Mac via
+[homebrew](http://brew.sh/):
+
+```bash
+brew install giter8
+```
+
 ---
 
 With installation out of the way, head over to the "[first project](first-project.html)"


### PR DESCRIPTION
When I followed the directions on installing `giter8` (I'm using OSX + zsh), the directions failed to work so I figured out how to install `giter8` with homebrew.