### PR TITLE
change JDK version info

### DIFF
--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -36,10 +36,7 @@ $ javac -version
 javac 1.7.0_10
 ```
 
-You need Java 7, which will show up as version 1.7. 
-
-Java 8 support in Scala is classed as experimental in Scala 2.11.x. If you
-aren't sure what this means, use Java 7.
+You need Java 7 or higher, which will show up as e.g. version 1.7.
 
 If you don't yet have Java installed, you can find out how to install
 it for your system


### PR DESCRIPTION
Scala 2.11 works fine on Java 8, there is no reason to stick with
Java 7 on Scala-version grounds.

(I don't know if there is some Scalatra-specific reason users might
want to stick with Java 7? if there is, that should be stated, rather
than saying Scala is the reason.)