### PR TITLE
Added trailing slash to guides link

### DIFF
--- a/content/getting-started/first-project.md
+++ b/content/getting-started/first-project.md
@@ -185,7 +185,7 @@ $ sbt
 
 Now that you've got a (rather simplistic) running application, you may want
 to [understand more](project-structure.html) about the project setup, or
-dive straight into our [guides](../../guides), which show you how to perform
+dive straight into our [guides](../../guides/), which show you how to perform
 common development tasks.
 
 Many of the Scalatra guides have companion code projects, so you can learn


### PR DESCRIPTION
Without the trailing slash, the link directs to a much less stylized or informative list of all guides without version information.