### PR TITLE
Added release announce for scalatra 2.6.5

### DIFF
--- a/content/news/2019-02-15-scalatra-2-6-5-released.md
+++ b/content/news/2019-02-15-scalatra-2-6-5-released.md
@@ -1,0 +1,22 @@
+---
+title: "Scalatra 2.6.5 is out"
+layout: news
+author: Naoki Takezoe
+twitter: takezoen
+date: 2019-02-15
+---
+
+The Scalatra team is pleased to announce the release of version 2.6.5 of the framework. 
+
+<!--more-->
+
+Here's the full list of changes from version 2.6.4:
+
+### Modules
+
+* Upgrade Json4s 3.6.3
+* Date & Time support for Swagger
+
+We have a plan to move [http4s](https://github.com/http4s/http4s) in Scalatra 3.0.0. We will continue to maintain Scalatra 2.x systems, but we will deprecate unnecessary functions for future Scalatra 3.0.0 in order to improve future maintainability.
+
+Thanks to all committers and contributors!

--- a/content/news/2019-02-15-scalatra-2-6-5-released.md
+++ b/content/news/2019-02-15-scalatra-2-6-5-released.md
@@ -10,7 +10,7 @@ The Scalatra team is pleased to announce the release of version 2.6.5 of the fra
 
 <!--more-->
 
-Here's the full list of changes from version 2.6.4:
+Here's the full list of changes for version 2.6.5:
 
 ### Modules
 

--- a/content/news/2019-02-15-scalatra-2-6-5-released.md
+++ b/content/news/2019-02-15-scalatra-2-6-5-released.md
@@ -1,8 +1,8 @@
 ---
 title: "Scalatra 2.6.5 is out"
 layout: news
-author: Naoki Takezoe
-twitter: takezoen
+author: Magnolia.K
+twitter: magnolia_k_
 date: 2019-02-15
 ---
 


### PR DESCRIPTION
There was an issue saying that project news has not been updated, so I made an announcement for the latest release.

https://github.com/scalatra/scalatra/issues/938