### PR TITLE
Fix typo of package name in doc.

### DIFF
--- a/content/guides/2.3/deployment/configuration.md
+++ b/content/guides/2.3/deployment/configuration.md
@@ -108,7 +108,7 @@ If you would like to move the `ScalatraBootstrap.scala` out of the default packa
 </web-app>
 ```
 
-Now your bootstrap class file can be located in the `com.example.app` package and be named `MyScalatraBootstrap.scala`.
+Now your bootstrap class file can be located in the `org.yourdomain.project` package and be named `MyScalatraBootstrap.scala`.
 
 #### Mounting multiple servlets (or filters)
 

--- a/content/guides/2.4/deployment/configuration.md
+++ b/content/guides/2.4/deployment/configuration.md
@@ -100,7 +100,7 @@ If you would like to move the `ScalatraBootstrap.scala` out of the default packa
 </web-app>
 ```
 
-Now your bootstrap class file can be located in the `com.example.app` package and be named `MyScalatraBootstrap.scala`.
+Now your bootstrap class file can be located in the `org.yourdomain.project` package and be named `MyScalatraBootstrap.scala`.
 
 #### Mounting multiple servlets (or filters)
 


### PR DESCRIPTION
I stumbled across some typo in older versions of documents.

When explain how ScalatraBootstrap is loaded,  the original PR here: #131 

> Now your bootstrap class file can be located in the `com.example.app` package and be named `MyScalatraBootstrap.scala`.

According the xml config, it should be `org.yourdomain.project` instead of `com.example.app`

It seems that some typo has been corrected in the later version of the document, but it still exists in the old version.