### PR TITLE
Update cors.md

### DIFF
--- a/content/guides/2.7/web-services/cors.md
+++ b/content/guides/2.7/web-services/cors.md
@@ -15,25 +15,25 @@ You can configure your application to be more restrictive by using the following
 ```scala
 // List the hosts and ports which will be allowed to make cross-origin requests, 
 // separated by commas (* by default).
-context.initParameters("org.scalatra.cors.allowedOrigins") = "http://example.com:8080,http://foo.example.com"
+context.setInitParameter("org.scalatra.cors.allowedOrigins", "http://example.com:8080,http://foo.example.com")
 
 // List what HTTP methods will be accepted. 
 // Available options are GET, POST, PUT, DELETE, HEAD, OPTIONS, and PATCH. 
 // All methods are accepted by default.
-context.initParameters("org.scalatra.cors.allowedMethods") = "GET"
+context.setInitParameter("org.scalatra.cors.allowedMethods", "GET")
 
 // Set a list of allowed HTTP headers, most headers are supported.
-context.initParameters("org.scalatra.cors.allowedHeaders") = "Content-Type"
+context.setInitParameter("org.scalatra.cors.allowedHeaders", "Content-Type")
 
 // Set the number of seconds that preflight requests can be cached by the client.
 // Default value is 0 seconds.
-context.initParameters("org.scalatra.cors.preflightMaxAge") = 1800
+context.setInitParameter("org.scalatra.cors.preflightMaxAge", "1800")
 
 // By default, cookies are not included in CORS requests. Set this to `true` to allow cookies.
-context.initParameters("org.scalatra.cors.allowCredentials") = true
+context.setInitParameter("org.scalatra.cors.allowCredentials", "true")
 
 // If CorsSupport needs to be disabled, set to false. Default: CorsSupport is enabled.
-context.initParameters("org.scalatra.cors.enable") = false
+context.setInitParameter("org.scalatra.cors.enable", "false")
 ```
 
 If you are configuring your application using web.xml, the corresponding xml configuration would be.
@@ -67,9 +67,9 @@ Recommended configuration:
 
 ```scala
 // Optional because * is the default
-context.initParameters("org.scalatra.cors.allowedOrigins") = "*"
+context.setInitParameter("org.scalatra.cors.allowedOrigins", "*")
 // Disables cookies, but required because browsers will not allow passing credentials to wildcard domains  
-context.initParameters("org.scalatra.cors.allowCredentials") = false
+context.setInitParameter("org.scalatra.cors.allowCredentials", "false")
 ```
 
 If you need allowedCredentials to be true, then you have to implement an options route and set the allowed domain:


### PR DESCRIPTION
Scalatra 2.7.0 supports the following syntax no more: `context.setInitParameter`