### PR TITLE
Update swagger api info constructor for 2.7.0

### DIFF
--- a/content/guides/2.7/swagger.md
+++ b/content/guides/2.7/swagger.md
@@ -220,7 +220,7 @@ controller to our application. Drop this code into a new file next to your
 package org.scalatra.example.swagger
 
 import org.scalatra.ScalatraServlet
-import org.scalatra.swagger.{ApiInfo, NativeSwaggerBase, Swagger}
+import org.scalatra.swagger.{ApiInfo, ContactInfo, LicenseInfo, NativeSwaggerBase, Swagger}
 
 
 class ResourcesApp(implicit val swagger: Swagger) extends ScalatraServlet with NativeSwaggerBase
@@ -229,9 +229,15 @@ object FlowersApiInfo extends ApiInfo(
     "The Flowershop API",
     "Docs for the Flowers API",
     "http://scalatra.org",
-    "apiteam@scalatra.org",
-    "MIT",
-    "http://opensource.org/licenses/MIT")
+    ContactInfo(
+      "Scalatra API Team",
+      "http://scalatra.org",
+      "apiteam@scalatra.org"
+    ),
+    LicenseInfo(
+      "MIT",
+      "http://opensource.org/licenses/MIT"
+    ))
 
 class FlowersSwagger extends Swagger(Swagger.SpecVersion, "1.0.0", FlowersApiInfo)
 ```


### PR DESCRIPTION
This constructor has been updated in https://github.com/scalatra/scalatra/pull/748 and needs the `ContactInfo` and `LicenseInfo` case classes now.