### PR TITLE
Remove initParameters property

### DIFF
--- a/content/guides/2.7/deployment/configuration.md
+++ b/content/guides/2.7/deployment/configuration.md
@@ -180,8 +180,8 @@ route matches.
 `context.setInitParameter(ScalatraBase.HostNameKey, "myapp.local")` or
 `context.setInitParameter("org.scalatra.HostName", "myapp.local")`
 
-`context.setInitParameter(ScalatraBase.PortKey, 443)` or
-`context.setInitParameter("org.scalatra.Port", 443)`
+`context.setInitParameter(ScalatraBase.PortKey, "443")` or
+`context.setInitParameter("org.scalatra.Port", "443")`
 
 `context.setInitParameter(ScalatraBase.ForceHttpsKey, "true")` or
 `context.setInitParameter("org.scalatra.ForceHttps", "true")`
@@ -206,12 +206,11 @@ if you'd like to see the alternate form.
 `context.setInitParameter(CorsSupport.AllowedMethodsKey, "GET,PUT")`
 `context.setInitParameter(CorsSupport.AllowedHeadersKey, "Content-Type")`
 `context.setInitParameter(CorsSupport.AllowCredentialsKey, "true")`
-`context.setInitParameter(CorsSupport.PreflightMaxAgeKey, 1800)`
+`context.setInitParameter(CorsSupport.PreflightMaxAgeKey, "1800")`
 
 ##### Async init params
 
-`context.setAttribute(AsyncSupport.ExecutionContextKey, executionContext)` or
-`context.setInitParameter("org.scalatra.ExecutionContext", executionContext)`
+`context.setAttribute(AsyncSupport.ExecutionContextKey, executionContext)`
 
 This key sets the `ExecutionContext` which Scalatra should use when creating an
 Akka `Future`.

--- a/content/guides/2.7/deployment/configuration.md
+++ b/content/guides/2.7/deployment/configuration.md
@@ -152,20 +152,6 @@ override def init(context: ServletContext) {
 }
 ```
 
-Each init param can be set in one of two ways.
-
-The first form looks like this:
-
-`context.setInitParameter(org.scalatra.EnvironmentKey, "production")`
-
-The second form has a bit of syntactic sugar on it, so it looks a little
-less Java:
-
-`context.initParameters("org.scalatra.environment") = "production"`
-
-The two forms are equivalent.
-
-
 ##### Environment init param
 
 `context.setInitParameter(org.scalatra.EnvironmentKey, "production")` or

--- a/content/guides/2.7/deployment/configuration.md
+++ b/content/guides/2.7/deployment/configuration.md
@@ -147,7 +147,7 @@ override def init(context: ServletContext) {
   context mount (new ArticlesServlet, "/articles/*")
 
   // Let's set the environment
-  context.initParameters("org.scalatra.environment") = "production"
+  context.setInitParameter("org.scalatra.environment", "production")
 
 }
 ```
@@ -169,7 +169,7 @@ The two forms are equivalent.
 ##### Environment init param
 
 `context.setInitParameter(org.scalatra.EnvironmentKey, "production")` or
-`context.initParameters("org.scalatra.environment") = "production"`
+`context.setInitParameter("org.scalatra.environment", "production")`
 
 This init param sets the application environment.
 
@@ -192,13 +192,13 @@ route matches.
 ##### Container init params
 
 `context.setInitParameter(ScalatraBase.HostNameKey, "myapp.local")` or
-`context.initParameters("org.scalatra.HostName") = "myapp.local"`
+`context.setInitParameter("org.scalatra.HostName", "myapp.local")`
 
 `context.setInitParameter(ScalatraBase.PortKey, 443)` or
-`context.initParameters("org.scalatra.Port") = 443`
+`context.setInitParameter("org.scalatra.Port", 443)`
 
 `context.setInitParameter(ScalatraBase.ForceHttpsKey, "true")` or
-`context.initParameters("org.scalatra.ForceHttps") = "true"`
+`context.setInitParameter("org.scalatra.ForceHttps", "true")`
 
 By default, the values for hostname, port, and SSL settings are inherited from
 the servlet container's settings. You can set these init params if you want to
@@ -225,7 +225,7 @@ if you'd like to see the alternate form.
 ##### Async init params
 
 `context.setAttribute(AsyncSupport.ExecutionContextKey, executionContext)` or
-`context.initParameters("org.scalatra.ExecutionContext") = executionContext`
+`context.setInitParameter("org.scalatra.ExecutionContext", executionContext)`
 
 This key sets the `ExecutionContext` which Scalatra should use when creating an
 Akka `Future`.

--- a/content/guides/2.7/http/authentication.md
+++ b/content/guides/2.7/http/authentication.md
@@ -38,7 +38,7 @@ Alternately, you can register a strategy using init params in
 `ScalatraBootstrap` or your application's `web.xml` file, using
 `scentry.strategies` as the key and the class name of your strategy as a value:
 
-`context.initParameters("scentry.strategies") = "UserPasswordStrategy"`
+`context.setInitParameter("scentry.strategies", "UserPasswordStrategy")`
 
 To write a Scentry Strategy, you'll need to implement the methods in
 [ScentryStrategy](https://github.com/scalatra/scalatra/blob/develop/auth/src/main/scala/org/scalatra/auth/ScentryStrategy.scala).


### PR DESCRIPTION
ref: https://github.com/scalatra/scalatra/pull/882

By this PR https://github.com/scalatra/scalatra/pull/882 , `initParameters` has been removed in order to support Scala 2.13 .
So I removed the way of using `initParameters` from documents.