### PR TITLE
Drop unneeded `jetty:stop` command

### DIFF
--- a/content/getting-started/first-project.md
+++ b/content/getting-started/first-project.md
@@ -175,7 +175,7 @@ To recompile and reload your application automatically, run the following:
 
 ```bash
 $ sbt
-> ~;jetty:stop;jetty:start
+> ~jetty:start
 ```
 
 Now that you've got a (rather simplistic) running application, you may want


### PR DESCRIPTION
Running `jetty:start` [automatically stops][1] any running instances of
the container.  Triggered restarts can be done simply via `~jetty:start`
or `~jetty:quickstart`.

[1]: https://github.com/earldouglas/xsbt-web-plugin/blob/4.2.1/docs/4.2.x.md#triggered-execution