### PR TITLE
removes broken link to riak persistence

### DIFF
--- a/content/guides/2.8/index.md
+++ b/content/guides/2.8/index.md
@@ -36,7 +36,6 @@ We've documented most aspects of working with Scalatra in a series of guides cov
 ### Persistence
 - [Introduction](persistence/introduction.html)
 - [MongoDB](persistence/mongodb.html)
-- [Riak](persistence/riak.html)
 - [Slick](persistence/slick.html)
 - [Squeryl](persistence/squeryl.html)
 


### PR DESCRIPTION
[Scalatra documentation website for version 2.8](https://scalatra.org/guides/2.8/) still contains a link to the no-longer existing riak persistence documentation. 

This PR removes that link.
