### PR TITLE
Update links to the Play Framework website

### DIFF
--- a/content/guides/2.3/views/twirl.md
+++ b/content/guides/2.3/views/twirl.md
@@ -5,7 +5,7 @@ title: Twirl
 layout: guides-2.3
 ---
 
-*Twirl* is the [Play 2 templating language](http://www.playframework.org/documentation/2.0/ScalaTemplates).
+*Twirl* is the [Play 2 templating language](https://www.playframework.com/documentation/2.0/ScalaTemplates).
 
 <div class="alert alert-info">
   <span class="badge badge-info"><i class="glyphicon glyphicon-flag"></i></span>
@@ -115,7 +115,7 @@ Your result?
 ## Full usage guide
 We have only provided a taste of what Twirl can do.
 Since it's an external project, we encourage you to also consult the
-[official documentation](http://www.playframework.org/documentation/2.0/ScalaTemplates).
+[official documentation](https://www.playframework.com/documentation/2.0/ScalaTemplates).
 
 The [sbt plugin's README](https://github.com/spray/twirl/blob/master/README.rst)
 also has a useful syntax summary.

--- a/content/guides/2.4/views/twirl.md
+++ b/content/guides/2.4/views/twirl.md
@@ -5,7 +5,7 @@ title: Twirl
 layout: guides-2.4
 ---
 
-*Twirl* is the [Play 2 templating language](http://www.playframework.org/documentation/2.0/ScalaTemplates).
+*Twirl* is the [Play 2 templating language](https://www.playframework.com/documentation/2.0/ScalaTemplates).
 
 <div class="alert alert-info">
   <span class="badge badge-info"><i class="glyphicon glyphicon-flag"></i></span>
@@ -115,7 +115,7 @@ Your result?
 ## Full usage guide
 We have only provided a taste of what Twirl can do.
 Since it's an external project, we encourage you to also consult the
-[official documentation](http://www.playframework.org/documentation/2.0/ScalaTemplates).
+[official documentation](https://www.playframework.com/documentation/2.0/ScalaTemplates).
 
 The [sbt plugin's README](https://github.com/spray/twirl/blob/master/README.rst)
 also has a useful syntax summary.

--- a/content/guides/2.5/views/twirl.md
+++ b/content/guides/2.5/views/twirl.md
@@ -3,7 +3,7 @@ title: Twirl
 layout: guides-2.5
 ---
 
-*Twirl* is the [Play 2 templating language](http://www.playframework.org/documentation/2.5.x/ScalaTemplates).
+*Twirl* is the [Play 2 templating language](https://www.playframework.com/documentation/2.5.x/ScalaTemplates).
 
 ---
 
@@ -112,7 +112,7 @@ Your result?
 ## Full usage guide
 We have only provided a taste of what Twirl can do.
 Since it's an external project, we encourage you to also consult the
-[official documentation](http://www.playframework.org/documentation/2.5.x/ScalaTemplates).
+[official documentation](https://www.playframework.com/documentation/2.5.x/ScalaTemplates).
 
 ## Rendering oddities
 

--- a/content/guides/2.6/views/twirl.md
+++ b/content/guides/2.6/views/twirl.md
@@ -3,7 +3,7 @@ title: Twirl
 layout: guides-2.6
 ---
 
-*Twirl* is the [Play 2 templating language](http://www.playframework.org/documentation/2.6.x/ScalaTemplates).
+*Twirl* is the [Play 2 templating language](https://www.playframework.com/documentation/2.6.x/ScalaTemplates).
 
 ---
 
@@ -112,7 +112,7 @@ Your result?
 ## Full usage guide
 We have only provided a taste of what Twirl can do.
 Since it's an external project, we encourage you to also consult the
-[official documentation](http://www.playframework.org/documentation/2.6.x/ScalaTemplates).
+[official documentation](https://www.playframework.com/documentation/2.6.x/ScalaTemplates).
 
 ## Rendering oddities
 

--- a/content/guides/2.7/views/twirl.md
+++ b/content/guides/2.7/views/twirl.md
@@ -3,7 +3,7 @@ title: Twirl
 layout: guides-2.7
 ---
 
-*Twirl* is the [Play 2 templating language](http://www.playframework.org/documentation/2.6.x/ScalaTemplates).
+*Twirl* is the [Play 2 templating language](https://www.playframework.com/documentation/2.6.x/ScalaTemplates).
 
 ---
 
@@ -112,7 +112,7 @@ Your result?
 ## Full usage guide
 We have only provided a taste of what Twirl can do.
 Since it's an external project, we encourage you to also consult the
-[official documentation](http://www.playframework.org/documentation/2.6.x/ScalaTemplates).
+[official documentation](https://www.playframework.com/documentation/2.6.x/ScalaTemplates).
 
 ## Rendering oddities
 

--- a/content/guides/2.8/views/twirl.md
+++ b/content/guides/2.8/views/twirl.md
@@ -112,7 +112,7 @@ Your result?
 ## Full usage guide
 We have only provided a taste of what Twirl can do.
 Since it's an external project, we encourage you to also consult the
-[official documentation](http://www.playframework.org/documentation/2.6.x/ScalaTemplates).
+[official documentation](https://www.playframework.com/documentation/2.6.x/ScalaTemplates).
 
 ## Rendering oddities
 

--- a/content/guides/3.0/views/twirl.md
+++ b/content/guides/3.0/views/twirl.md
@@ -114,7 +114,7 @@ Your result?
 ## Full usage guide
 We have only provided a taste of what Twirl can do.
 Since it's an external project, we encourage you to also consult the
-[official documentation](http://www.playframework.org/documentation/2.6.x/ScalaTemplates).
+[official documentation](https://www.playframework.com/documentation/2.6.x/ScalaTemplates).
 
 ## Rendering oddities
 


### PR DESCRIPTION
It looks like the Play website has moved over to [www.playframework.com](https://www.playframework.com).  This PR updates the old links to the new URLs.