### PR TITLE
Delete CNAME

### DIFF
--- a/static/CNAME
+++ b/static/CNAME
@@ -1,1 +1,0 @@
-scalatra.org


### PR DESCRIPTION
CNAME isn't needed if GitHub Pages is deployed from GitHub Actions.